### PR TITLE
Speed up Gaussian normal initialization from SfM points

### DIFF
--- a/dn_splatter/data/coolermap_dataparser.py
+++ b/dn_splatter/data/coolermap_dataparser.py
@@ -51,7 +51,7 @@ class CoolerMapDataParserConfig(ColmapDataParserConfig):
     """Which format the normal maps in camera frame are saved in."""
     normals_from: Literal["depth", "pretrained"] = "pretrained"
     """If no ground truth normals, generate normals either from sensor depths or from pretrained model."""
-    load_pcd_normals: bool = False
+    load_pcd_normals: bool = True
     """Whether to load pcd normals for normal initialisation"""
     load_3D_points: bool = True
     """Whether to load the 3D points from the colmap reconstruction."""
@@ -178,7 +178,7 @@ class CoolerMapDataParser(ColmapDataParser):
         # load depths
         if self.config.depth_mode != "none" and self.config.load_depths:
             if not (self.config.data / "mono_depth").exists():
-                CONSOLE.print(f"Load depth has been set to true, but could not find mono_depth path. Trying to generate aligned mono depth frames.")
+                CONSOLE.print("Load depth has been set to true, but could not find mono_depth path. Trying to generate aligned mono depth frames.")
                 ColmapToAlignedMonoDepths(
                     data=self.config.data, mono_depth_network=self.config.mono_pretrain
                 ).main()

--- a/dn_splatter/data/g_sdfstudio_dataparser.py
+++ b/dn_splatter/data/g_sdfstudio_dataparser.py
@@ -51,7 +51,7 @@ class GSDFStudioDataParserConfig(DataParserConfig):
     """Which depth data to load"""
     is_euclidean_depth: bool = False
     """Whether input depth maps are Euclidean distances (or z-distances)."""
-    load_pcd_normals: bool = False
+    load_pcd_normals: bool = True
     """Whether to load pcd normals for normal initialisation"""
     scale_factor: float = 1.0
     """How much to scale the camera origins by."""

--- a/dn_splatter/data/mushroom_dataparser.py
+++ b/dn_splatter/data/mushroom_dataparser.py
@@ -87,7 +87,7 @@ class MushroomDataParserConfig(DataParserConfig):
     """Which format the normal maps in camera frame are saved in."""
     normals_from: Literal["depth", "pretrained"] = "pretrained"
     """If no ground truth normals, generate normals either from sensor depths or from pretrained model."""
-    load_pcd_normals: bool = False
+    load_pcd_normals: bool = True
     """Whether to load pcd normals for normal initialisation"""
 
     # general configs

--- a/dn_splatter/data/replica_dataparser.py
+++ b/dn_splatter/data/replica_dataparser.py
@@ -65,7 +65,7 @@ class ReplicaDataParserConfig(DataParserConfig):
     """Which format the normal maps in camera frame are saved in."""
     normals_from: Literal["depth", "pretrained"] = "depth"
     """If no ground truth normals, generate normals either from sensor depths or from pretrained model."""
-    load_pcd_normals: bool = False
+    load_pcd_normals: bool = True
     """Whether to load pcd normals for normal initialisation"""
     initialisation_type: Literal["mesh", "rgbd"] = "rgbd"
     """Which method to generate initial point clouds from"""

--- a/dn_splatter/dn_model.py
+++ b/dn_splatter/dn_model.py
@@ -15,7 +15,6 @@ from torch import Tensor
 from torch.nn import Parameter
 from torchmetrics.image import PeakSignalNoiseRatio, StructuralSimilarityIndexMeasure
 from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
-from tqdm import tqdm
 
 from dn_splatter.losses import DepthLoss, DepthLossType, TVLoss
 from dn_splatter.metrics import DepthMetrics, RGBMetrics
@@ -183,43 +182,40 @@ class DNSplatterModel(SplatfactoModel):
         avg_dist = distances.mean(dim=-1, keepdim=True)
 
         # init normals if present
-        if (
-            self.seed_points is not None
-            and len(self.seed_points) == 3
-            and self.training
-        ):  # type: ignore
-            self.normals_seed = self.seed_points[-1].float()  # type: ignore
-            self.normals_seed = self.normals_seed / torch.norm(
-                self.normals_seed, dim=-1, keepdim=True
-            )
-            normals = torch.nn.Parameter(self.normals_seed.detach())
-            scales = torch.log(avg_dist.repeat(1, 3))
-            scales[:, 2] = 0  # torch.log((avg_dist / 10)[:, 0])
-            scales = torch.nn.Parameter(scales)
-            quats = torch.zeros(len(self.normals_seed), 4)
-            z_vector = torch.tensor(
-                [0, 0, 1], dtype=torch.float, device=self.normals_seed.device
-            )
-            for i in tqdm(
-                range(len(self.normals_seed)),
-                desc="Initialising normals... (slow) this operation is not batched yet",
-            ):
-                rotation_matrix = rotate_vector_to_vector(
-                    z_vector, self.normals_seed[i]
+        with torch.no_grad():
+            if (
+                self.seed_points is not None and len(self.seed_points) == 3
+            ):  # type: ignore
+                CONSOLE.print(
+                    "[bold yellow]Initialising Gaussian normals from SfM estimates"
                 )
-                quaternion = matrix_to_quaternion(rotation_matrix)
-                quats[i, :] = quaternion
-            quats = torch.nn.Parameter(quats)
-        else:
-            scales = torch.nn.Parameter(torch.log(avg_dist.repeat(1, 3)))
-            quats = torch.nn.Parameter(random_quat_tensor(num_points))
+                self.normals_seed = self.seed_points[-1].float()  # type: ignore
+                self.normals_seed = self.normals_seed / torch.norm(
+                    self.normals_seed, dim=-1, keepdim=True
+                )
+                normals = torch.nn.Parameter(self.normals_seed.detach())
+                scales = torch.log(avg_dist.repeat(1, 3))
+                scales[:, 2] = torch.log((avg_dist / 10)[:, 0])
+                scales = torch.nn.Parameter(scales.detach())
+                quats = torch.zeros(len(self.normals_seed), 4)
+                mat = rotate_vector_to_vector(
+                    torch.tensor(
+                        [0, 0, 1], dtype=torch.float, device=self.normals_seed.device
+                    ).repeat(self.normals_seed.shape[0], 1),
+                    self.normals_seed,
+                )
+                quats = matrix_to_quaternion(mat)
+                quats = torch.nn.Parameter(quats.detach())
+            else:
+                scales = torch.nn.Parameter(torch.log(avg_dist.repeat(1, 3)))
+                quats = torch.nn.Parameter(random_quat_tensor(num_points))
 
-            # init random normals based on the above scales and quats
-            normals = F.one_hot(torch.argmin(scales, dim=-1), num_classes=3).float()
-            rots = quat_to_rotmat(quats)
-            normals = torch.bmm(rots, normals[:, :, None]).squeeze(-1)
-            normals = F.normalize(normals, dim=1)
-            normals = torch.nn.Parameter(normals.detach())
+                # init random normals based on the above scales and quats
+                normals = F.one_hot(torch.argmin(scales, dim=-1), num_classes=3).float()
+                rots = quat_to_rotmat(quats)
+                normals = torch.bmm(rots, normals[:, :, None]).squeeze(-1)
+                normals = F.normalize(normals, dim=1)
+                normals = torch.nn.Parameter(normals.detach())
 
         self.gauss_params = torch.nn.ParameterDict(
             {
@@ -599,7 +595,8 @@ class DNSplatterModel(SplatfactoModel):
             rots = quat_to_rotmat(quats_crop)
             normals = torch.bmm(rots, normals[:, :, None]).squeeze(-1)
             normals = F.normalize(normals, dim=1)
-            if True:
+            if self.step < self.config.normal_direction_warmup_steps:
+                # flip normals based on current camera view vector during warmup
                 viewdirs = (
                     -means_crop.detach() + camera.camera_to_worlds.detach()[..., :3, 3]
                 )
@@ -1611,59 +1608,81 @@ def rotate_vector_to_vector(v1: Tensor, v2: Tensor):
     Returns a rotation matrix that rotates v1 to align with v2.
     """
     assert v1.dim() == v2.dim()
-    assert v1.dim() == 1
-    u = v1 / torch.norm(v1)
-    Ru = v2 / torch.norm(v2)
-    I: Tensor = torch.eye(3, device=v1.device)  # noqa: E741
+    assert v1.shape[-1] == 3
+    if v1.dim() == 1:
+        v1 = v1[None, ...]
+        v2 = v2[None, ...]
+    N = v1.shape[0]
+
+    u = v1 / torch.norm(v1, dim=-1, keepdim=True)
+    Ru = v2 / torch.norm(v2, dim=-1, keepdim=True)
+    I = torch.eye(3, 3, device=v1.device).unsqueeze(0).repeat(N, 1, 1)
+
     # the cos angle between the vectors
-    c = torch.dot(u, Ru)
+    c = torch.bmm(u.view(N, 1, 3), Ru.view(N, 3, 1)).squeeze(-1)
+
     eps = 1.0e-10
-    if torch.abs(c - 1.0) < eps:
-        # same direction
-        return I
-    elif torch.abs(c + 1.0) < eps:
-        # opposite direction
-        return -I
-    else:
-        # the cross product matrix of a vector to rotate around
-        K = torch.outer(Ru, u) - torch.outer(u, Ru)
-        # Rodrigues' formula
-        return I + K + (K @ K) / (1 + c)
+    # the cross product matrix of a vector to rotate around
+    K = torch.bmm(Ru.unsqueeze(2), u.unsqueeze(1)) - torch.bmm(
+        u.unsqueeze(2), Ru.unsqueeze(1)
+    )
+    # Rodrigues' formula
+    ans = I + K + (K @ K) / (1 + c)[..., None]
+    same_direction_mask = torch.abs(c - 1.0) < eps
+    same_direction_mask = same_direction_mask.squeeze(-1)
+    opposite_direction_mask = torch.abs(c + 1.0) < eps
+    opposite_direction_mask = opposite_direction_mask.squeeze(-1)
+    ans[same_direction_mask] = torch.eye(3, device=v1.device)
+    ans[opposite_direction_mask] = -torch.eye(3, device=v1.device)
+    return ans
 
 
-def matrix_to_quaternion(matrix: Tensor):
+def matrix_to_quaternion(rotation_matrix: Tensor):
     """
     Convert a 3x3 rotation matrix to a unit quaternion.
+
+    TODO: properly batchify this
     """
-    assert matrix.shape == (3, 3)
-    trace = torch.trace(matrix)
+    if rotation_matrix.dim() == 2:
+        rotation_matrix = rotation_matrix[None, ...]
+    assert rotation_matrix.shape[1:] == (3, 3)
 
-    if trace > 0:
-        S = torch.sqrt(trace + 1.0) * 2
-        w = 0.25 * S
-        x = (matrix[2, 1] - matrix[1, 2]) / S
-        y = (matrix[0, 2] - matrix[2, 0]) / S
-        z = (matrix[1, 0] - matrix[0, 1]) / S
-    elif (matrix[0, 0] > matrix[1, 1]) and (matrix[0, 0] > matrix[2, 2]):
-        S = torch.sqrt(1.0 + matrix[0, 0] - matrix[1, 1] - matrix[2, 2]) * 2
-        w = (matrix[2, 1] - matrix[1, 2]) / S
-        x = 0.25 * S
-        y = (matrix[0, 1] + matrix[1, 0]) / S
-        z = (matrix[0, 2] + matrix[2, 0]) / S
-    elif matrix[1, 1] > matrix[2, 2]:
-        S = torch.sqrt(1.0 + matrix[1, 1] - matrix[0, 0] - matrix[2, 2]) * 2
-        w = (matrix[0, 2] - matrix[2, 0]) / S
-        x = (matrix[0, 1] + matrix[1, 0]) / S
-        y = 0.25 * S
-        z = (matrix[1, 2] + matrix[2, 1]) / S
-    else:
-        S = torch.sqrt(1.0 + matrix[2, 2] - matrix[0, 0] - matrix[1, 1]) * 2
-        w = (matrix[1, 0] - matrix[0, 1]) / S
-        x = (matrix[0, 2] + matrix[2, 0]) / S
-        y = (matrix[1, 2] + matrix[2, 1]) / S
-        z = 0.25 * S
+    traces = torch.vmap(torch.trace)(rotation_matrix)
+    quaternion = torch.zeros(
+        rotation_matrix.shape[0], 4, dtype=rotation_matrix.dtype, device=rotation_matrix.device
+    )
+    for i in range(rotation_matrix.shape[0]):
+        matrix = rotation_matrix[i]
+        trace = traces[i]
+        if trace > 0:
+            S = torch.sqrt(trace + 1.0) * 2
+            w = 0.25 * S
+            x = (matrix[2, 1] - matrix[1, 2]) / S
+            y = (matrix[0, 2] - matrix[2, 0]) / S
+            z = (matrix[1, 0] - matrix[0, 1]) / S
+        elif (matrix[0, 0] > matrix[1, 1]) and (matrix[0, 0] > matrix[2, 2]):
+            S = torch.sqrt(1.0 + matrix[0, 0] - matrix[1, 1] - matrix[2, 2]) * 2
+            w = (matrix[2, 1] - matrix[1, 2]) / S
+            x = 0.25 * S
+            y = (matrix[0, 1] + matrix[1, 0]) / S
+            z = (matrix[0, 2] + matrix[2, 0]) / S
+        elif matrix[1, 1] > matrix[2, 2]:
+            S = torch.sqrt(1.0 + matrix[1, 1] - matrix[0, 0] - matrix[2, 2]) * 2
+            w = (matrix[0, 2] - matrix[2, 0]) / S
+            x = (matrix[0, 1] + matrix[1, 0]) / S
+            y = 0.25 * S
+            z = (matrix[1, 2] + matrix[2, 1]) / S
+        else:
+            S = torch.sqrt(1.0 + matrix[2, 2] - matrix[0, 0] - matrix[1, 1]) * 2
+            w = (matrix[1, 0] - matrix[0, 1]) / S
+            x = (matrix[0, 2] + matrix[2, 0]) / S
+            y = (matrix[1, 2] + matrix[2, 1]) / S
+            z = 0.25 * S
 
-    return torch.tensor([w, x, y, z], dtype=matrix.dtype, device=matrix.device)
+        quaternion[i] = torch.tensor(
+            [w, x, y, z], dtype=matrix.dtype, device=matrix.device
+        )
+    return quaternion
 
 
 def scale_rot_to_inv_cov3d(scale, quat, return_sqrt=False):


### PR DESCRIPTION
This speeds up Gaussian normal initialization if `--load-pcd-normals True ` flag is used. Addressing OOM simultaneously as discovered in #2 . Problem was that I was not vectorizing some intermediate quaternion operations, which should be sped up now, although not entirely resolved.


Initializing normal directions from sfm estimates can help convergence. Here are some examples I quickly tested:

Replica room0 at 100 iterations without initialization vs with initialization vs gt normal. 
<img src = "https://github.com/maturk/dn-splatter/assets/30566358/0284e383-df12-42ad-8f73-685c0147b4e0" width = '200'>  <img src = "https://github.com/maturk/dn-splatter/assets/30566358/e0958470-7791-40c6-b41a-784a20d4c9df" width = '200'>  <img src = "https://github.com/maturk/dn-splatter/assets/30566358/6be6d001-a94b-4e02-8667-1b964894827f" width = '200'> 


Dataset from #2 :
at 100 iterations without initialization vs with initialization vs monocular normal estimate. 


<img src = "https://github.com/maturk/dn-splatter/assets/30566358/a3b4c363-3986-41d8-ba8b-24ffa4dcaaae" width = '200'> 

<img src = "https://github.com/maturk/dn-splatter/assets/30566358/9a7b7f10-1834-43c8-8795-fa406e75acc0" width = '200'> 
<img src = "https://github.com/maturk/dn-splatter/assets/30566358/444c0e4e-58bb-4cb9-bc9c-c35cfa05053c" width = '200'> 




