### PR TITLE
dn-splatter-big variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### <p align="center">[🌐Project Page](https://maturk.github.io/dn-splatter/) | [🖨️ArXiv](https://arxiv.org/abs/2403.17822) </p>
 
-This is repo implements depth and normal supervision for 3DGS and several mesh extraction scripts.
+This repo implements depth and normal supervision for 3DGS and several mesh extraction scripts.
 
 https://github.com/maturk/dn-splatter/assets/30566358/9b3ffe9d-5fe9-4b8c-8426-d578bf877a35
 
@@ -32,11 +32,20 @@ https://github.com/maturk/dn-splatter/assets/30566358/9b3ffe9d-5fe9-4b8c-8426-d5
       <a href="#evaluation">Evaluation</a>
     </li>
     <li>
+      <a href="#acknowledgements">Acknowledgements</a>
+    </li>
+    <li>
+      <a href="#citation">Citation</a>
+    </li>
+    <li>
       <a href="#developers">Developers</a>
     </li>
   </ol>
 </details>
 
+## Updates
+- 16.04.2024: Support for [DSINE](https://github.com/baegwangbin/DSINE) monocular normal supervision.
+- 20.04.2024: `dn-splatter-big`: a variant featuring less aggressive Gaussian culling threshold, which leads to an increased number of Gaussians in the optimized scene.  On certain datasets, this can lead to better novel-view synthesis results.
 ## Installation
 ### Method 1. Using Conda and Pip
 Follow installation instructions for [Nerfstudio](https://docs.nerf.studio/quickstart/installation.html). This repo is compatible with a `nerfstudio` conda environment.
@@ -100,6 +109,9 @@ ns-train dn-splatter --data PATH_TO_DATA \
                  --pipeline.model.use-sparse-loss True \
                  --pipeline.model.use-binary-opacities True \
 ```
+
+### dn-splatter-big:
+We also provide a `dn-splatter-big` variant that increases the number of Gaussians in the scene which may enhance the quality of novel-view synthesis.  This increases training time and hardware requirements. Simply replace the `dn-splatter` keyword with `dn-splatter-big` in the above commands.
 
 ## Mesh
 To extract a mesh, run the following command:

--- a/dn_splatter/dn_config.py
+++ b/dn_splatter/dn_config.py
@@ -69,5 +69,68 @@ dn_splatter = MethodSpecification(
         viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
         vis="viewer",
     ),
-    description="Our version of gaussian splatting for experimentation.",
+    description="DN-Splatter: depth and normal priors for 3DGS",
+)
+
+dn_splatter_big = MethodSpecification(
+    config=TrainerConfig(
+        method_name="dn-splatter-big",
+        steps_per_eval_image=500,
+        steps_per_eval_batch=500,
+        steps_per_save=1000000,
+        steps_per_eval_all_images=1000000,
+        max_num_iterations=30000,
+        mixed_precision=False,
+        pipeline=DNSplatterPipelineConfig(
+            datamanager=DNSplatterManagerConfig(
+                dataparser=NormalNerfstudioConfig(load_3D_points=True)
+            ),
+            model=DNSplatterModelConfig(
+                cull_alpha_thresh=0.005,
+                continue_cull_post_densification=False,
+            ),
+        ),
+        optimizers={
+            "means": {
+                "optimizer": AdamOptimizerConfig(lr=1.6e-4, eps=1e-15),
+                "scheduler": ExponentialDecaySchedulerConfig(
+                    lr_final=1.6e-6,
+                    max_steps=30000,
+                ),
+            },
+            "features_dc": {
+                "optimizer": AdamOptimizerConfig(lr=0.0025, eps=1e-15),
+                "scheduler": None,
+            },
+            "features_rest": {
+                "optimizer": AdamOptimizerConfig(lr=0.0025 / 20, eps=1e-15),
+                "scheduler": None,
+            },
+            "opacities": {
+                "optimizer": AdamOptimizerConfig(lr=0.05, eps=1e-15),
+                "scheduler": None,
+            },
+            "scales": {
+                "optimizer": AdamOptimizerConfig(lr=0.005, eps=1e-15),
+                "scheduler": None,
+            },
+            "quats": {
+                "optimizer": AdamOptimizerConfig(lr=0.001, eps=1e-15),
+                "scheduler": None,
+            },
+            "camera_opt": {
+                "optimizer": AdamOptimizerConfig(lr=1e-3, eps=1e-15),
+                "scheduler": ExponentialDecaySchedulerConfig(
+                    lr_final=5e-5, max_steps=30000
+                ),
+            },
+            "normals": {
+                "optimizer": AdamOptimizerConfig(lr=1e-3, eps=1e-15),
+                "scheduler": None,
+            },
+        },
+        viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
+        vis="viewer",
+    ),
+    description="DN-Splatter Big variant",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ include = ["dn_splatter*"]
 
 [project.entry-points.'nerfstudio.method_configs']
 dn_splatter = 'dn_splatter.dn_config:dn_splatter'
+dn_splatter_big = 'dn_splatter.dn_config:dn_splatter_big'
 #g-nerfacto = 'dn_splatter.eval.eval_configs:gnerfacto'
 #g-depthfacto = 'dn_splatter.eval.eval_configs:gdepthfacto'
 #g-neusfacto = 'dn_splatter.eval.eval_configs:gneusfacto'


### PR DESCRIPTION
Added a `dn-splatter-big` variant which increases the number of Gaussians in the scene. This can be beneficial for some difficult scenes for novel-view synthesis. 

Here are the results on a single indoor capture, the `vr_room` scene, from the `mushroom` dataset:

| vr room  | Test within a sequence | --- | --- | Test with a different sequence | --- | --- |
|------------------|------------------------|--------------------------------| ---- | --- | --- | --- |
|                  | psnr  | ssim | lpips | psnr | ssim | lpips |
| dn-splatter      | 26.86  | 0.8777 | 0.117 | 23.64  | 0.8263 | 0.1716|
| dn-splatter-big  | 26.93  | 0.8806 | 0.1099| 23.67  | 0.8274 | 0.1656|


