### PR TITLE
Fix mushroom mesh eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,16 @@ Use the `coolermap` dataparser with COLMAP datasets as follows:
 ```bash
 ns-train dn-splatter [OPTIONS] coolermap --data [DATASET_PATH]
 ```
+An example:
+```bash
+ns-train dn-splatter \
+--pipeline.model.use-depth-loss True \
+--pipeline.model.mono-depth-lambda 0.1 \
+--pipeline.model.use-depth-smooth-loss True \
+--pipeline.model.use-normal-loss True \
+--pipeline.model.normal-supervision (mono/depth) \
+coolermap --data [DATASET_PATH] --load_normals True
+```
 
 ### [MuSHRoom](https://github.com/TUTvision/MuSHRoom)
 Support for Kinect and iPhone RGB-D trajectories.
@@ -391,7 +401,7 @@ python dn_splatter/eval/eval_mesh_mushroom.py --gt_mesh_path [GT_Mesh_Path] --pr
 
 To get mesh metrics for other datasets ScanNet++/Replica or custom datasets, run the following command:
 ```bash
-python dn_splatter/eval/eval_mesh.py --gt_mesh [GT_Mesh_Path] --pred_mesh [Pred_Mesh_Path]
+python dn_splatter/eval/eval_mesh.py --gt_mesh [GT_Mesh_Path] --pred_mesh [Pred_Mesh_Path] --dataset [dataset_name]
 ```
 
 # Acknowledgements

--- a/dn_splatter/eval/eval_mesh.py
+++ b/dn_splatter/eval/eval_mesh.py
@@ -2,6 +2,7 @@
 adapted from go_surf scripts:
 https://github.com/JingwenWang95/go-surf/blob/master/tools/mesh_metrics.py#L33
 """
+
 from pathlib import Path
 
 import numpy as np
@@ -10,6 +11,15 @@ import trimesh
 import tyro
 from matplotlib import pyplot as plt
 from scipy.spatial import cKDTree
+
+transform = np.array(
+    [
+        [1, 0, 0, 0],
+        [0, 0, -1, 0],
+        [0, 1, 0, 0],
+        [0, 0, 0, 1],
+    ]
+)
 
 
 def get_align_transformation(rec_meshfile, gt_meshfile):
@@ -143,10 +153,14 @@ def compute_metrics(mesh_pred, mesh_target):
     return rst
 
 
-def main(gt_mesh: Path, pred_mesh: Path, align: bool = False):
+def main(
+    gt_mesh: Path, pred_mesh: Path, align: bool = False, dataset: str = "scannetpp"
+):
     gt_mesh_ply = trimesh.load(gt_mesh, process=False)
     pd_mesh_ply = trimesh.load(pred_mesh, process=False)
 
+    if dataset == "scannetpp":
+        pd_mesh_ply = pd_mesh_ply.apply_transform(transform)
     if align:
         transformation = get_align_transformation(str(pred_mesh), str(gt_mesh))
         pd_mesh_ply = pd_mesh_ply.apply_transform(transformation)

--- a/dn_splatter/eval/eval_mesh_mushroom.py
+++ b/dn_splatter/eval/eval_mesh_mushroom.py
@@ -3,7 +3,7 @@ import json
 import os
 from copy import deepcopy
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 
 import cv2
 import numpy as np
@@ -546,48 +546,30 @@ def trimesh_from_open3d_mesh(open3d_mesh):
 
 def main(
     gt_mesh_path: Path,  # path to gt mesh folder
-    pred_mesh_path: Path,  # path to the pred mesh folder
+    pred_mesh_path: Path,  # path to the pred mesh path
     device: Literal["kinect", "iphone"] = "iphone",
-    method: Literal["nerfacto", "gs", "neusfacto", "tsdf"] = "gs",
+    output: Path = Path("."),  # output path
+    transform_path: Optional[Path] = None,  # assume nerfacto style mesh as input
+    meta_data_path: Optional[Path] = None,  # assume neusfacto style mesh as input
 ):
     gt_mesh = o3d.io.read_triangle_mesh(str(gt_mesh_path / "gt_mesh.ply"))
     gt_mesh = gt_mesh.remove_unreferenced_vertices()
-    if method == "nerfacto":
-        pred_mesh = trimesh.load(
-            str(pred_mesh_path / "mesh" / "poisson_mesh.ply"),
-            force="mesh",
-            process=False,
-        )
-    elif method == "gs":
-        pred_mesh = trimesh.load(
-            str(pred_mesh_path / "mesh" / "DepthAndNormalMapsPoisson_poisson_mesh.ply"),
-            force="mesh",
-            process=False,
-        )
-    elif method == "tsdf":
-        pred_mesh = trimesh.load(
-            str(pred_mesh_path / "tsdf" / "TSDFfusion_mesh.ply"),
-            force="mesh",
-            process=False,
-        )
-    elif method == "neusfacto":
-        pred_mesh = trimesh.load(
-            str(pred_mesh_path / "mesh" / "neusfacto.ply"), force="mesh", process=False
-        )
+
+    pred_mesh = trimesh.load(
+        pred_mesh_path,
+        force="mesh",
+        process=False,
+    )
 
     # first transfer nerfstudio mesh back to real scale
-    if method in ["nerfacto", "gs", "tsdf"]:
-        nerf_scale = json.load(open(pred_mesh_path / "dataparser_transforms.json"))[
-            "scale"
-        ]
+    if transform_path and transform_path.exists():
+        nerf_scale = json.load(open(transform_path))["scale"]
         scale_mat = np.eye(4).astype(np.float32)
         scale_mat[:3] *= nerf_scale
         align_T = np.linalg.inv(scale_mat)
         pred_mesh.apply_transform(align_T)
-    elif method == "neusfacto":
-        meta = load_from_json(
-            os.path.join(gt_mesh_path / device / "sdfstudio_data" / "meta_data.json")
-        )
+    if meta_data_path and meta_data_path.exists():
+        meta = load_from_json(os.path.join(meta_data_path))
         inverse_matrix = meta["worldtogt"]
         pred_mesh.apply_transform(inverse_matrix)
 
@@ -606,23 +588,18 @@ def main(
         pred_mesh = pred_mesh.apply_transform(initial_transformation)
 
     pred_mesh = open3d_mesh_from_trimesh(pred_mesh)
-    if gt_mesh_path.name in ["activity", "computer"]:
-        print(gt_mesh_path.name)
-        pred_mesh = cut_mesh(gt_mesh, pred_mesh, kernel_size=15, dilate=False)
-    else:
-        pred_mesh = cut_mesh(gt_mesh, pred_mesh, kernel_size=15, dilate=True)
+
+    pred_mesh = cut_mesh(gt_mesh, pred_mesh, kernel_size=15, dilate=True)
 
     # evaluate culled mesh
-    o3d.io.write_triangle_mesh(
-        str(pred_mesh_path / "mesh" / "poisson_mesh_cull.ply"), pred_mesh
-    )
+    o3d.io.write_triangle_mesh(str(output / "mesh_cull.ply"), pred_mesh)
     print("finished save and cut the mesh")
 
     gt_mesh = trimesh_from_open3d_mesh(gt_mesh)
     pred_mesh = trimesh_from_open3d_mesh(pred_mesh)
 
     rst = compute_metrics(pred_mesh, gt_mesh)
-    json.dump(rst, open(pred_mesh_path / "mesh" / "metrics.json", "w"))
+    json.dump(rst, open(output / "metrics.json", "w"))
 
 
 if __name__ == "__main__":

--- a/dn_splatter/eval/eval_mesh_mushroom.py
+++ b/dn_splatter/eval/eval_mesh_mushroom.py
@@ -546,12 +546,25 @@ def trimesh_from_open3d_mesh(open3d_mesh):
 
 def main(
     gt_mesh_path: Path,  # path to gt mesh folder
-    pred_mesh_path: Path,  # path to the pred mesh path
+    pred_mesh_path: Path,  # path to the pred mesh ply
     device: Literal["kinect", "iphone"] = "iphone",
     output: Path = Path("."),  # output path
     transform_path: Optional[Path] = None,  # assume nerfacto style mesh as input
     meta_data_path: Optional[Path] = None,  # assume neusfacto style mesh as input
 ):
+    """Evaluate mushroom dataset meshes
+
+    Args:
+        gt_mesh_path: Path to gt mesh folder ../room_datasets/[scene_name]
+        pred_mesh_path: Path to predicted mesh .ply
+        device: iphone or kinect sequence
+        output: output path
+        transform_path: transform path for depth-nerfacto/nerfacto models
+        meta_data_path: meta data path for sdfstudio / monosdf / neusfacto models
+
+    Returns:
+        None
+    """
     gt_mesh = o3d.io.read_triangle_mesh(str(gt_mesh_path / "gt_mesh.ply"))
     gt_mesh = gt_mesh.remove_unreferenced_vertices()
 
@@ -599,6 +612,7 @@ def main(
     pred_mesh = trimesh_from_open3d_mesh(pred_mesh)
 
     rst = compute_metrics(pred_mesh, gt_mesh)
+    print(f"Saving results to: {output / 'metrics.json'}")
     json.dump(rst, open(output / "metrics.json", "w"))
 
 


### PR DESCRIPTION
simplify mesh eval script for mushroom, the command can be:
`python dn_splatter/eval/eval_mesh_mushroom.py --gt_mesh_path [Path to mushroom]/[room_name] --pred_mesh_path [path to mesh .ply] --output [output_path]`