### PR TITLE
Fix normal discrepancy

### DIFF
--- a/dn_splatter/dn_model.py
+++ b/dn_splatter/dn_model.py
@@ -566,17 +566,15 @@ class DNSplatterModel(SplatfactoModel):
             normals = normals @ camera.camera_to_worlds.squeeze(0)[:3, :3]
 
             xys = self.xys[0, ...].detach()
-            self.depths = self.depths[0, ...]
-            self.num_tiles_hit = self.num_tiles_hit[0, ...]
 
             normals_im: Tensor = rasterize_gaussians(  # type: ignore
                 xys,
-                self.depths,
-                self.radii.detach(),
-                self.conics.detach(),
-                self.num_tiles_hit.detach(),
+                self.depths[0, ...],
+                self.radii,
+                self.conics[0,...],
+                self.num_tiles_hit[0,...],
                 normals,
-                torch.sigmoid(opacities_crop).detach(),
+                torch.sigmoid(opacities_crop),
                 H,
                 W,
                 BLOCK_WIDTH,

--- a/dn_splatter/scripts/render_model.py
+++ b/dn_splatter/scripts/render_model.py
@@ -94,7 +94,6 @@ class RenderModel:
 
                 # save all outputs
                 save_outputs_helper(
-                    self.output_dir,
                     rgb_out if self.render_rgb else None,
                     gt_img if self.render_rgb else None,
                     depth_color if self.render_depth else None,
@@ -103,6 +102,7 @@ class RenderModel:
                     depth if self.render_depth else None,
                     normal_gt if self.render_normal else None,
                     normal if self.render_normal else None,
+                    self.output_dir,
                     image_name,
                 )
 


### PR DESCRIPTION
As noted in #35, there was a discrepancy between pre gspat v1.0.0 and gsplat v1.0.0 normal estimation. This PR fixes the issue.
The problem was interesting, apparently it is best to allow gradients to fully flow to most gaussian parameters for better surface normal estimation, especially the opacity values made the biggest difference. 

With detach(): "rgb_psnr": 22.428760528564453
<img src="https://github.com/maturk/dn-splatter/assets/30566358/ef2c1766-414e-4d73-a8a3-ff15c6ebeadc" alt="with detach()" width="300" height="300">

Without detach(): "rgb_psnr": 22.47365951538086
<img src="https://github.com/maturk/dn-splatter/assets/30566358/99a4273f-d2de-431e-b567-9d30eecab80a" alt="without detach()" width="300" height="300">


Impact on RGB psnr metrics is minimal, but significant improvement in normal estimation is achieved with the fix which now replicates the original dn-splatter code before gsplat v1.0.0 upgrade. 

Command to reproduce training:

```
ns-train dn-splatter --max-num-iterations 20000 --pipeline.model.use-depth-loss True --pipeline.model.sensor-
depth-lambda 0.2 --pipeline.model.use-depth-smooth-loss True --pipeline.model.use-normal-loss True --pipeline.model.normal-supervision mono  scannetpp --data path_to/scannetpp/ --sequence 8b5caf3398
```
