### PR TITLE
Pin PyMCubes in 'pyproject.toml' to 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "pymeshlab>=2022.2.post2; platform_machine != 'arm64' and platform_machine != 'aarch64'",
     "pytest",
     "vdbfusion",
-    "PyMCubes",
+    "PyMCubes==0.1.4",
     "omnidata-tools",
     "pytorch-lightning",
     "torch",


### PR DESCRIPTION
Because `PyMCubes` is not pinned, pip tries to grab the latest version of `PyMCbues` which as of July 3, 2024 is v0.1.6.

`PyMCubes` v0.1.6 [requires](https://github.com/pmneila/PyMCubes/blob/649095092a629acdd1d9588d44d589ab7a9cae5b/pyproject.toml#L2) `numpy~=2.0`, which in turn requires the python version to be >=3.9, "[The Python versions supported by this release are 3.9-3.12](https://numpy.org/devdocs/release/2.0.0-notes.html)".

This is incompatible with the [nerfstudio installation](https://docs.nerf.studio/quickstart/installation.html) instructions which by default recommends python 3.8.

This change pins `PyMCubes` to 0.1.4 so `dn-splatter` can still be consistent with nerfstudio and support python 3.8.

Note: `PyMCubes==0.1.4` is [consistent](https://github.com/maturk/dn-splatter/blob/13726bfad5b32bda7c4908be99e4a24ff5eeab46/pixi.lock#L6498) with the pixi.lock file.