### PR TITLE
gt_normal default to None

### DIFF
--- a/dn_splatter/dn_model.py
+++ b/dn_splatter/dn_model.py
@@ -684,6 +684,8 @@ class DNSplatterModel(SplatfactoModel):
                 )
             )
             gt_normal = (1 + gt_normal) / 2
+        else:
+            gt_normal = None
 
         additional_data = {
             "scales": self.scales,


### PR DESCRIPTION
I noticed that it's not possible to train the code without using the normals loss because in `get_loss_dict` the code assumes `gt_normal` has been set to some value. For example the following command fails with `gt_normal not defined`

```bash
ns-train dn-splatter \
--pipeline.model.use-depth-loss True \
--pipeline.model.depth-lambda 0.2 \
--pipeline.model.predict_normals False \
--pipeline.model.use-normal-loss False \
--pipeline.model.use_normal_tv_loss False \
replica \
--sequence room0 \
--load_normals False \
--load_pcd_normals False \
--num_sfm_points 1_000_000
```

Thanks for the great implementation/papers!