### PR TITLE
Support more datasets for ags-mesh

### DIFF
--- a/dn_splatter/data/coolermap_dataparser.py
+++ b/dn_splatter/data/coolermap_dataparser.py
@@ -47,8 +47,8 @@ class CoolerMapDataParserConfig(ColmapDataParserConfig):
     """Which mono depth pretrain model to use."""
     load_normals: bool = False
     """Set to true to use ground truth normal maps"""
-    normal_format: Literal["opencv", "opengl"] = "opengl"
-    """Which format the normal maps in camera frame are saved in."""
+    normal_format: Literal["omnidata", "dsine"] = "omnidata"
+    """Which monocular normal network was used to generate normals (they have different coordinate systems)."""
     normals_from: Literal["depth", "pretrained"] = "pretrained"
     """If no ground truth normals, generate normals either from sensor depths or from pretrained model."""
     load_pcd_normals: bool = True

--- a/dn_splatter/data/dn_dataset.py
+++ b/dn_splatter/data/dn_dataset.py
@@ -59,7 +59,7 @@ class GDataset(InputDataset):
         if "normal_format" in self.metadata:
             self.normal_format = self.metadata["normal_format"]
         else:
-            self.normal_format = "opengl"
+            self.normal_format = "omnidata"
 
         if "normal_frame" in self.metadata:
             self.normal_frame = self.metadata["normal_frame"]
@@ -204,7 +204,7 @@ class GDataset(InputDataset):
     def get_normal_image_from_path(
         self,
         path,
-        normal_format: Literal["opencv", "opengl"],
+        normal_format: Literal["omnidata", "dsine"],
         normal_frame: Literal["camera_frame", "world_frame"],
         c2w: Optional[None] = None,
     ):
@@ -212,7 +212,7 @@ class GDataset(InputDataset):
 
         Args:
             path: path to normal file
-            normal_format: which format "opencv" or "opengl" the normal data is stored in. We convert automatically to opencv
+            normal_format: which format "omnidata" or "dsine" the normal data is stored in. We convert automatically to omnidata format.
             c2w: optional c2w transform if normals should be in world frame
         """
         if path.suffix == ".png":
@@ -226,7 +226,7 @@ class GDataset(InputDataset):
 
         normal_map = torch.from_numpy(normal_map.astype("float32") / 255.0).float()
 
-        if normal_format == "opengl" and normal_frame == "camera_frame":
+        if normal_format == "omnidata" and normal_frame == "camera_frame":
             # convert normal map from opengl to opencv
             h, w, _ = normal_map.shape
             normal_map = normal_map.view(-1, 3)

--- a/dn_splatter/data/g_sdfstudio_dataparser.py
+++ b/dn_splatter/data/g_sdfstudio_dataparser.py
@@ -246,7 +246,7 @@ class GSDFStudioDataparser(DataParser):
 
         # Safety check to make sure we load correct normal conventions
         if self.config.load_for_sdfstudio:
-            normal_format = "opengl"
+            normal_format = "dsine"
             normal_frame = "world_frame"
         else:
             normal_format = "opengl"

--- a/dn_splatter/data/mushroom_dataparser.py
+++ b/dn_splatter/data/mushroom_dataparser.py
@@ -86,8 +86,8 @@ class MushroomDataParserConfig(DataParserConfig):
     """Whether to load depth confidence masks"""
     load_normals: bool = True
     """Set to true to load normal maps"""
-    normal_format: Literal["opencv", "opengl"] = "opengl"
-    """Which format the normal maps in camera frame are saved in."""
+    normal_format: Literal["omnidata", "dsine"] = "omnidata"
+    """Which monocular normal network was used to generate normals (they have different coordinate systems)."""
     normals_from: Literal["depth", "pretrained"] = "pretrained"
     """If no ground truth normals, generate normals either from sensor depths or from pretrained model."""
     load_pcd_normals: bool = True

--- a/dn_splatter/data/nrgbd_dataparser.py
+++ b/dn_splatter/data/nrgbd_dataparser.py
@@ -70,8 +70,8 @@ class NRGBDDataParserConfig(DataParserConfig):
     """Set to true to use ground truth normal maps"""
     load_depths: bool = True
     """Whether to load depth maps"""
-    normal_format: Literal["opencv", "opengl"] = "opengl"
-    """Which format the normal maps in camera frame are saved in."""
+    normal_format: Literal["omnidata", "dsine"] = "omnidata"
+    """Which monocular normal network was used to generate normals (they have different coordinate systems)."""
     normals_from: Literal["depth", "pretrained"] = "depth"
     """If no ground truth normals, generate normals either from sensor depths or from pretrained model."""
     load_pcd_normals: bool = False

--- a/dn_splatter/data/replica_dataparser.py
+++ b/dn_splatter/data/replica_dataparser.py
@@ -61,8 +61,8 @@ class ReplicaDataParserConfig(DataParserConfig):
     """Whether to load depth maps"""
     load_normals: bool = True
     """Set to true to use ground truth normal maps"""
-    normal_format: Literal["opencv", "opengl"] = "opengl"
-    """Which format the normal maps in camera frame are saved in."""
+    normal_format: Literal["omnidata", "dsine"] = "omnidata"
+    """Which monocular normal network was used to generate normals (they have different coordinate systems)."""
     normals_from: Literal["depth", "pretrained"] = "depth"
     """If no ground truth normals, generate normals either from sensor depths or from pretrained model."""
     load_pcd_normals: bool = True

--- a/dn_splatter/data/scannetpp_dataparser.py
+++ b/dn_splatter/data/scannetpp_dataparser.py
@@ -59,8 +59,8 @@ class ScanNetppDataParserConfig(ColmapDataParserConfig):
     """Which mono depth pretrain model to use."""
     load_normals: bool = True
     """Set to true to use ground truth normal maps"""
-    normal_format: Literal["opencv", "opengl"] = "opengl"
-    """Which format the normal maps in camera frame are saved in."""
+    normal_format: Literal["omnidata", "dsine"] = "omnidata"
+    """Which monocular normal network was used to generate normals (they have different coordinate systems)."""
     normals_from: Literal["pretrained", "none"] = "pretrained"
     """If no ground truth normals, generate normals either from sensor depths or from pretrained model."""
     load_pcd_normals: bool = False

--- a/dn_splatter/scripts/normals_from_pretrain.py
+++ b/dn_splatter/scripts/normals_from_pretrain.py
@@ -56,7 +56,7 @@ class NormalsFromPretrained:
     """Whether to make low resolution or full image resolution normal estimates"""
     force_images_dir: bool = False
     """Force to use img_dir_name instead of transforms.json if found"""
-    model_type: Literal["omnidata", "dsine"] = "omnidata"
+    normal_format: Literal["omnidata", "dsine"] = "omnidata"
 
     def main(self):
         if (
@@ -70,14 +70,14 @@ class NormalsFromPretrained:
             image_paths = [
                 self.data_dir / Path(frame["file_path"]) for frame in meta["frames"]
             ]
-            if self.model_type == "omnidata":
+            if self.normal_format == "omnidata":
                 if self.resolution == "low":
                     run_monocular_normals(images=image_paths, save_path=self.save_path)
                 else:
                     run_monocular_normals_hd(
                         images=image_paths, save_path=self.save_path
                     )
-            elif self.model_type == "dsine":
+            elif self.normal_format == "dsine":
                 run_monocular_dsine(images=image_paths, save_path=self.save_path)
 
         elif len(os.listdir(self.data_dir / Path(self.img_dir_name))) != 0:
@@ -85,14 +85,14 @@ class NormalsFromPretrained:
                 f"[bold yellow]Found images in /{self.img_dir_name}, using these to generate mononormals."
             )
             image_paths = get_filename_list(self.data_dir / Path(self.img_dir_name))
-            if self.model_type == "omnidata":
+            if self.normal_format == "omnidata":
                 if self.resolution == "low":
                     run_monocular_normals(images=image_paths, save_path=self.save_path)
                 else:
                     run_monocular_normals_hd(
                         images=image_paths, save_path=self.save_path
                     )
-            elif self.model_type == "dsine":
+            elif self.normal_format == "dsine":
                 run_monocular_dsine(images=image_paths, save_path=self.save_path)
         else:
             CONSOLE.print(
@@ -412,7 +412,7 @@ def normals_from_omnidata_hd(
 def normals_from_depths(
     path_to_transforms: Path,
     save_path: Optional[Path] = None,
-    normal_format: Literal["opencv", "opengl"] = "opengl",
+    normal_format: Literal["omnidata", "dsine"] = "omnidata",
     is_euclidean_depth: bool = False,
 ) -> None:
     """Normal maps from depth maps
@@ -494,7 +494,7 @@ def normals_from_depths(
             @ torch.diag(
                 torch.tensor([1, -1, -1, 1], device=c2w.device, dtype=c2w.dtype)
             )
-            if normal_format == "opencv"
+            if normal_format == "omnidata"
             else c2w,
             device="cpu",
             smooth=False,

--- a/pixi.toml
+++ b/pixi.toml
@@ -25,7 +25,7 @@ example = {cmd = "pwd", depends_on=["download-omnidata", "download-data-sample",
 ## first download polycam only if ls fails (checking that file isn't already downloaded), || is used to check if file exists, if not move on to following command
 download-polycam = {cmd="ls datasets/polycam/6g-first-scan-poly.zip || wget -P datasets/polycam https://huggingface.co/datasets/pablovela5620/sample-polycam-room/resolve/main/6g-first-scan-poly.zip"}
 convert-poly-to-ns = {cmd="ls datasets/polycam/6g-first-scan-poly/transforms.json || ns-process-data polycam --data datasets/polycam/6g-first-scan-poly.zip --output-dir datasets/polycam/6g-first-scan-poly --use-depth", depends_on=["download-polycam"]}
-generate-normals = {cmd="ls datasets/polycam/6g-first-scan-poly/normals_from_pretrain/frame_00001.png || python dn_splatter/scripts/normals_from_pretrain.py --data-dir datasets/polycam/6g-first-scan-poly --model-type dsine", depends_on=["convert-poly-to-ns"]}
+generate-normals = {cmd="ls datasets/polycam/6g-first-scan-poly/normals_from_pretrain/frame_00001.png || python dn_splatter/scripts/normals_from_pretrain.py --data-dir datasets/polycam/6g-first-scan-poly --normal-format dsine", depends_on=["convert-poly-to-ns"]}
 generate-pointcloud = "ls datasets/polycam/6g-first-scan-poly/iphone_pointcloud.ply || python dn_splatter/data/mushroom_utils/pointcloud_utils.py --data-path datasets/polycam/6g-first-scan-poly"
 train-polycam = """
 ns-train dn-splatter \


### PR DESCRIPTION
Addresses issues in #102 

- `depth_normal_consistency.py` now supports both omnidata and dsine normals for filtering inconsistent depth maps
- normal-nerfstudio dataparser (used for custom datasets in the nerfstudio format) now supports the ags-mesh method by adding option to load confidence masks.

cc: @XuqianRen 