### PR TITLE
Add Cropbox Support to DN-Splatter Mesh Extraction

### DIFF
--- a/dn_splatter/export_mesh.py
+++ b/dn_splatter/export_mesh.py
@@ -118,7 +118,7 @@ class GSMeshExporter:
         if self.cropbox_scale is None:
             self.cropbox_scale = (1.0, 1.0, 1.0)
 
-        return OrientedBox(
+        return OrientedBox.from_params(
             pos=self.cropbox_pos,
             rpy=self.cropbox_rpy,
             scale=self.cropbox_scale,

--- a/dn_splatter/export_mesh.py
+++ b/dn_splatter/export_mesh.py
@@ -539,6 +539,7 @@ class LevelSetExtractor(GSMeshExporter):
         assert isinstance(pipeline.model, SplatfactoModel)
 
         model: SplatfactoModel = pipeline.model
+        crop_box = self.cropbox()
 
         # assert hasattr(pipeline.model,"compute_level_surface_points_from_camera_fast")
 
@@ -580,6 +581,14 @@ class LevelSetExtractor(GSMeshExporter):
                     img_surface_points = frame_outputs[surface_level]["points"]
                     img_surface_colors = frame_outputs[surface_level]["colors"]
                     img_surface_normals = frame_outputs[surface_level]["normals"]
+
+                    if crop_box is not None:
+                        inside_crop = crop_box.within(img_surface_points).squeeze()
+                        if inside_crop.sum() == 0:
+                            continue
+                        img_surface_points = img_surface_points[inside_crop]
+                        img_surface_colors = img_surface_colors[inside_crop]
+                        img_surface_normals = img_surface_normals[inside_crop]
 
                     surface_levels_outputs[surface_level]["points"] = torch.cat(
                         [

--- a/dn_splatter/export_mesh.py
+++ b/dn_splatter/export_mesh.py
@@ -842,6 +842,7 @@ class TSDFFusion(GSMeshExporter):
         assert isinstance(pipeline.model, SplatfactoModel)
 
         model: SplatfactoModel = pipeline.model
+        crop_box = self.cropbox()
 
         TSDFvolume = vdbfusion.VDBVolume(
             voxel_size=self.voxel_size, sdf_trunc=self.sdf_truc, space_carving=True
@@ -862,7 +863,10 @@ class TSDFFusion(GSMeshExporter):
                 if "mask" in data:
                     mask = data["mask"]
                 camera = cameras[image_idx : image_idx + 1]
-                outputs = model.get_outputs_for_camera(camera=camera)
+                outputs = model.get_outputs_for_camera(
+                    camera=camera,
+                    obb_box=crop_box
+                )
                 assert "depth" in outputs
                 depth_map = outputs["depth"]
                 c2w = torch.eye(4, dtype=torch.float, device=depth_map.device)

--- a/dn_splatter/export_mesh.py
+++ b/dn_splatter/export_mesh.py
@@ -346,6 +346,7 @@ class DepthAndNormalMapsPoisson(GSMeshExporter):
         assert isinstance(pipeline.model, SplatfactoModel)
 
         model: SplatfactoModel = pipeline.model
+        crop_box = self.cropbox()
 
         with torch.no_grad():
             cameras: Cameras = pipeline.datamanager.train_dataset.cameras  # type: ignore
@@ -457,6 +458,14 @@ class DepthAndNormalMapsPoisson(GSMeshExporter):
 
                     normal_map = outputs["surface_normal"].cpu()
                     normal_map = normal_map.view(-1, 3)[indices]
+
+                if crop_box is not None:
+                    inside_crop = crop_box.within(xyzs).squeeze()
+                    if inside_crop.sum() == 0:
+                        continue
+                    xyzs = xyzs[inside_crop]
+                    rgbs = rgbs[inside_crop]
+                    normal_map = normal_map[inside_crop]
 
                 points.append(xyzs)
                 colors.append(rgbs)

--- a/dn_splatter/export_mesh.py
+++ b/dn_splatter/export_mesh.py
@@ -20,6 +20,7 @@ from dn_splatter.utils.camera_utils import (
 )
 from nerfstudio.cameras.cameras import Cameras
 from nerfstudio.models.splatfacto import SplatfactoModel
+from nerfstudio.data.scene_box import OrientedBox
 from nerfstudio.utils.eval_utils import eval_setup
 from nerfstudio.utils.rich_utils import CONSOLE
 
@@ -97,6 +98,31 @@ class GSMeshExporter:
     """Path to the trained config YAML file."""
     output_dir: Path = Path("./mesh_exports/")
     """Path to the output directory."""
+
+    cropbox_pos: Optional[Annotated[Tuple[float, float, float], "x, y, z"]] = None
+    """Cropbox position for the mesh."""
+    cropbox_rpy: Optional[Annotated[Tuple[float, float, float], "rx, ry, rz"]] = None
+    """Cropbox rotation for the mesh."""
+    cropbox_scale: Optional[Annotated[Tuple[float, float, float], "sx, sy, sz"]] = None
+    """Cropbox scale for the mesh."""
+
+    def cropbox(self) -> Optional[OrientedBox]:
+        """Returns the cropbox for the mesh."""
+        if self.cropbox_pos is None and self.cropbox_rpy is None and self.cropbox_scale is None:
+            return None
+
+        if self.cropbox_pos is None:
+            self.cropbox_pos = (0.0, 0.0, 0.0)
+        if self.cropbox_rpy is None:
+            self.cropbox_rpy = (0.0, 0.0, 0.0)
+        if self.cropbox_scale is None:
+            self.cropbox_scale = (1.0, 1.0, 1.0)
+
+        return OrientedBox(
+            pos=self.cropbox_pos,
+            rpy=self.cropbox_rpy,
+            scale=self.cropbox_scale,
+        )
 
 
 @dataclass

--- a/dn_splatter/export_mesh.py
+++ b/dn_splatter/export_mesh.py
@@ -946,6 +946,7 @@ class Open3DTSDFFusion(GSMeshExporter):
         assert isinstance(pipeline.model, SplatfactoModel)
 
         model: SplatfactoModel = pipeline.model
+        crop_box = self.cropbox()
 
         volume = o3d.pipelines.integration.ScalableTSDFVolume(
             voxel_length=self.voxel_size,
@@ -964,7 +965,10 @@ class Open3DTSDFFusion(GSMeshExporter):
                 if "mask" in data:
                     mask = data["mask"]
                 camera = cameras[image_idx : image_idx + 1]
-                outputs = model.get_outputs_for_camera(camera=camera)
+                outputs = model.get_outputs_for_camera(
+                    camera=camera,
+                    obb_box=crop_box,
+                )
                 assert "depth" in outputs
                 depth_map = outputs["depth"]
                 c2w = torch.eye(4, dtype=torch.float, device=depth_map.device)


### PR DESCRIPTION
This PR adds cropbox support to the DN-Splatter mesh extraction pipeline. Users can now specify a crop region using position, rotation, and scale to extract a mesh from a spatially bounded subset of the Gaussians. This is useful for focusing on subregions of interest or removing unwanted geometry.

### Changes
- Added `--cropbox-pos`, `--cropbox-rpy` and `--cropbox-scale` to the cli interface
  - `--cropbox-pos`: center position (x, y, z), defaults to `(0, 0, 0)`
  - `--cropbox-rpy`: rotation in degrees (roll, pitch, yaw), defaults to `(0, 0, 0)`
  - `--cropbox-scale`: axis-aligned scale (sx, sy, sz), defaults to `(1, 1, 1)`
- Integrated the cropbox into each of the mesh extraction pipelines
  
### Example Usage
```bash
gs-mesh \
  --cropbox-pos 0.0 0.0 0.0 \
  --cropbox-rot 0.0 0.0 0.0 \
  --cropbox-scale 2.0 2.0 2.0
```

Note that only one of the parameters needs to be set, to make the others default, as all are needed to apply the cropbox

### Implementation Notes
- The cropbox is implemented using the Nerfstudio Orientbox
- Rotation is parsed as Euler angles (in radians)

### Checklist
- [X] Cropbox parameter parsing via tyro
- [X] Tested `tsdf` mesh extraction
- [X] Tested `o3dtsdf` mesh extraction
- [X] Tested `dn` mesh extraction
- [X] Tested `sugar-coarse` mesh extraction
- [X] Tested `gaussians` mesh extraction (Getting an error from the model.normals, seems to originate from my custom model. Would be grateful, if someone could test this for me)
- [X] Tested `marching` mesh extraction (Scene I used for testing does not appear to achieve the density of gaussians required for mesh extraction, also would be grateful for some help, as I am a bit tight on time atm)


